### PR TITLE
time skip bug fixed

### DIFF
--- a/Assets/Resources/Scripts/Controllers/TimeController.cs
+++ b/Assets/Resources/Scripts/Controllers/TimeController.cs
@@ -4,12 +4,19 @@ using UnityEngine;
 
 public class TimeController : MonoBehaviour
 {
-    public int[] speeds;
+    public float[] speeds;
 
-    float timeBetweenTicks;
+    float curSpeed;
     float timer = 0;
 
     bool isPaused = true;
+
+    /*
+     Level 1: 1 tick per second => 1
+     Level 2: 2 ticks per second => .5f
+     Level 3: 4 ticks per second => .25f
+     Level 4: 8 ticks per second => .125f
+     */
 
 
     private void Start()
@@ -17,7 +24,7 @@ public class TimeController : MonoBehaviour
         EventManager.StartListening("PauseSpeed", TogglePause);
         EventManager.StartListening("SpeedChange", ChangeSpeed);
 
-        timeBetweenTicks = 1 / (float) speeds[0];
+        curSpeed = speeds[0];
     }
 
 
@@ -32,7 +39,7 @@ public class TimeController : MonoBehaviour
     void CalculateTimeToTick()
     {
         timer += Time.deltaTime;
-        if (timer >= timeBetweenTicks)
+        if (timer >= curSpeed)
         {
             EventManager.TriggerEvent("Tick", null);
             timer = 0;
@@ -48,9 +55,7 @@ public class TimeController : MonoBehaviour
             return;
         }
 
-        int newSpeed = speeds[newSpeedLevel];
-
-        timeBetweenTicks = 1 / (float) newSpeed;
+        curSpeed = speeds[newSpeedLevel];
     }
 
 

--- a/Assets/Resources/Scripts/CultureScripts/CultureComponents/Culture.cs
+++ b/Assets/Resources/Scripts/CultureScripts/CultureComponents/Culture.cs
@@ -269,7 +269,6 @@ public class Culture : MonoBehaviour
     {
         Tile = newTile;
         tileInfo = newTile.GetComponent<TileInfo>();
-        maxOnTile = tileInfo.tileType == affinity ? tileInfo.popBase + 2 : tileInfo.popBase;
     }
 
     void SetTile(Tile newTile)

--- a/Assets/Resources/Scripts/CultureScripts/StatIndicators/FoodAmountIndicatorGenerator.cs
+++ b/Assets/Resources/Scripts/CultureScripts/StatIndicators/FoodAmountIndicatorGenerator.cs
@@ -34,5 +34,10 @@ public class FoodAmountIndicatorGenerator : MonoBehaviour
         _amountFoodChange = 0;
     }
 
-  
+    private void OnDestroy()
+    {
+        EventManager.StopListening("Tick", OnTick);
+    }
+
+
 }

--- a/Assets/Resources/Scripts/UI/PlayScreen/CultureHighlightPanel.cs
+++ b/Assets/Resources/Scripts/UI/PlayScreen/CultureHighlightPanel.cs
@@ -26,7 +26,19 @@ public class CultureHighlightPanel : MonoBehaviour
 
     void Update()
     {
-        rectTransform.anchoredPosition = Camera.main.WorldToScreenPoint(cultureObj.transform.position);
+        MoveOrDestroyPanel();
+    }
+
+    void MoveOrDestroyPanel()
+    {
+        if (cultureObj == null)
+        {
+            Destroy(gameObject);
+        }
+        else
+        {
+            rectTransform.anchoredPosition = Camera.main.WorldToScreenPoint(cultureObj.transform.position);
+        }
     }
 
     void OnInteractiveMouseUp(Dictionary<string, object> mouseButton)


### PR DESCRIPTION
Fixed a bug where a NullReferenceException was thrown on a Tick command, causing the counter reset to be skipped and resulting in many ticks happening in a single moment. Also resolved a bug where the CultureDisplayPanel would glitch out and stick around after a culture was destroyed. 